### PR TITLE
Fix stale netgraph nodes reused on restart

### DIFF
--- a/vrrp_functions.h
+++ b/vrrp_functions.h
@@ -128,4 +128,4 @@ char            vrrp_thread_create_vrid(struct vrrp_vr *);
 int		vrrp_netgraph_bridge_create(char *);
 int		vrrp_netgraph_create_virtualiface(struct vrrp_vr *);
 int		vrrp_netgraph_shutdown(int, char *);
-int		vrrp_netgraph_shutdown_allnodes(void);
+int		vrrp_netgraph_teardown(void);

--- a/vrrp_main.c
+++ b/vrrp_main.c
@@ -242,6 +242,7 @@ main(int argc, char **argv)
 	bzero(&vr_ptr, sizeof(vr_ptr));
 	syslog(LOG_NOTICE, "initializing threads and all VRID");
 	vrrp_thread_initialize();
+	vrrp_netgraph_teardown();  /* Clean stale nodes from previous run */
 	syslog(LOG_NOTICE, "reading configuration file %s", copt.conffile);
 	while (!coderet) {
 		vr = (struct vrrp_vr *)calloc(1, sizeof(struct vrrp_vr));

--- a/vrrp_netgraph.c
+++ b/vrrp_netgraph.c
@@ -243,7 +243,7 @@ int vrrp_netgraph_create_virtualiface(struct vrrp_vr *vr) {
 	return 0;
 }
 
-int vrrp_netgraph_shutdown_allnodes(void) {
+int vrrp_netgraph_teardown(void) {
 	struct nodeinfo *ninfo;
 	struct namelist *nlist;
 	struct ng_mesg *ngmsg;

--- a/vrrp_netgraph.c
+++ b/vrrp_netgraph.c
@@ -243,6 +243,25 @@ int vrrp_netgraph_create_virtualiface(struct vrrp_vr *vr) {
 	return 0;
 }
 
+/*
+ * Check if a netgraph node exists by ID.
+ * Returns 1 if node exists, 0 if not, -1 on error.
+ */
+static int vrrp_netgraph_node_exists(int ng_control_socket, ng_ID_t node_id) {
+	struct ng_mesg *reply;
+	char path[256];
+
+	snprintf(path, sizeof(path), "[%x]:", node_id);
+	if (NgSendMsg(ng_control_socket, path, NGM_GENERIC_COOKIE, NGM_NODEINFO, NULL, 0) < 0)
+		return 0;  /* Node doesn't exist */
+
+	if (NgAllocRecvMsg(ng_control_socket, &reply, NULL) < 0)
+		return -1;  /* Error receiving reply */
+
+	free(reply);
+	return 1;  /* Node exists */
+}
+
 int vrrp_netgraph_teardown(void) {
 	struct nodeinfo *ninfo;
 	struct namelist *nlist;
@@ -261,10 +280,21 @@ int vrrp_netgraph_teardown(void) {
 	ninfo = nlist->nodeinfo;
 	while (nlist->numnames > 0) {
 		if (! strncmp(ninfo->name, VRRP_NETGRAPH_BASENAME, strlen(VRRP_NETGRAPH_BASENAME))) {
-			snprintf(path, sizeof(path), "%s:", ninfo->name);
+			ng_ID_t node_id = ninfo->id;
+
+			/* Shutdown by ID to avoid name reuse races */
+			snprintf(path, sizeof(path), "[%x]:", node_id);
 			vrrp_netgraph_shutdown(ng_control_socket, path);
+
+			/*
+			 * Wait for node to actually be destroyed.
+			 * No timeout needed: kernel panics if node won't die
+			 * (NGF_REALLY_DIE flag), so this loop always terminates.
+			 */
+			while (vrrp_netgraph_node_exists(ng_control_socket, node_id) == 1)
+				usleep(1000);  /* 1ms poll */
 		}
-		ninfo++;	
+		ninfo++;
 		nlist->numnames--;
 	}
 

--- a/vrrp_signal.c
+++ b/vrrp_signal.c
@@ -60,7 +60,7 @@ vrrp_signal_quit(int sig)
 	struct ether_addr ethaddr;
 
 	vrrp_thread_mutex_lock();
-	vrrp_netgraph_shutdown_allnodes();
+	vrrp_netgraph_teardown();
 	while (vr_ptr[cpt]) {
 		ethaddr = vrrp_list_get_first(vr_ptr[cpt]);
 		vrrp_interface_vripaddr_delete(vr_ptr[cpt]);


### PR DESCRIPTION
## Problem

After shutdown or restart, stale netgraph nodes can persist with old IP addresses. When freevrrpd restarts and creates a new eiface, it searches for *any* unhooked eiface node—not specifically the one it just created. If an orphaned node exists, it grabs that instead, inheriting the wrong IP configuration.

### Race condition on restart

1. Stop signal sent to freevrrpd
2. freevrrpd unhooks from ngeth0 (but node still exists with old IP like .250)
3. freevrrpd process exits
4. New freevrrpd starts immediately  
5. Creates new eiface
6. Searches for unhooked eiface → finds old ngeth0 still lingering
7. Uses old ngeth0 → wrong IP

### Root cause

In `vrrp_netgraph.c:155-177`, after creating a new eiface, the code searches for ANY unhooked eiface node. If a stale orphaned node exists from a previous run, it may grab that instead of the freshly created one.

### RFC alignment

RFC 5798 (VRRPv3) and RFC 3768 (VRRPv2) define Initialize as a clean starting state. While OS-level cleanup is an implementation detail, the intent is clear: Initialize should not carry forward stale configuration.

## Changes

### Commit 1: Add startup teardown
- Rename `vrrp_netgraph_shutdown_allnodes()` to `vrrp_netgraph_teardown()` for clarity
- Call `vrrp_netgraph_teardown()` at startup after thread init to clean stale nodes

### Commit 2: Make teardown synchronous
- `NgSendMsg` for `NGM_SHUTDOWN` is async—returns before kernel processes it
- Use node ID paths (`[id]:`) instead of name paths to avoid TOCTOU races
- Poll with `NGM_NODEINFO` until specific node ID is confirmed destroyed
- 1ms sleep between polls to avoid CPU spin
- No timeout needed: kernel panics (`NGF_REALLY_DIE`) if node won't die

## Testing

- Built successfully on FreeBSD 14.3
- Verified `kill -9` followed by restart no longer fails with "File exists"
- Verified restart no longer reuses stale nodes with wrong IP