### PR TITLE
Fix config parse crash on missing '=' and vlanlist strcmp typo

### DIFF
--- a/vrrp_conf.c
+++ b/vrrp_conf.c
@@ -61,6 +61,11 @@ vrrp_conf_ident_option_arg(char *chaine, char *option, char *arg)
 			exit(-1);
 		}
 	}
+	if (chaine[i] == 0) {
+		syslog(LOG_ERR, "malformed config line (no '='): %s", chaine);
+		arg[0] = '\0';
+		return -1;
+	}
 	i++;
 	while (chaine[i] == ' ' && chaine[i] != 0) {
 		i++;

--- a/vrrp_vlanlist.c
+++ b/vrrp_vlanlist.c
@@ -93,7 +93,7 @@ vrrp_vlanlist_delete(struct vrrp_vr * vr, char *vlan_ifname)
 {
 	struct vrrp_vlan_list *e = vr->vr_if->vlanp;
 
-	while (e->next && strcpy(vlan_ifname, e->vlan_ifname))
+	while (e->next && strcmp(vlan_ifname, e->vlan_ifname) != 0)
 		e = e->next;
 	if (!e->next)
 		return -1;


### PR DESCRIPTION
## Summary
- **vrrp_conf.c**: When a config line has no `=` character, `vrrp_conf_lecture_line()` sets `r = NULL` then immediately dereferences `*r`. Fixed by returning an error when `=` is missing.
- **vrrp_vlanlist.c**: `vrrp_vlanlist_delete()` uses `strcpy` where `strcmp` was intended. The comparison always runs to the tail and the function always returns -1. No VLAN entry was ever actually deleted.