### PR TITLE
Fix compiler warnings: unused variable, format types, format security

### DIFF
--- a/vrrp_ah.c
+++ b/vrrp_ah.c
@@ -600,10 +600,10 @@ int hexdump(unsigned char *zone, int len) {
     unsigned char *ptr;
 
     ptr = zone;
-    fprintf(stderr,"-- hexdump at %p (%d bytes long) --",zone,len);
+    fprintf(stderr,"-- hexdump at %p (%d bytes long) --",(void *)zone,len);
     for( i = 0 ;i < len;i++) {
 	if((i%16)==0)
-	    fprintf(stderr,"\n%p ",ptr+i);
+	    fprintf(stderr,"\n%p ",(void *)(ptr+i));
 	if((i%8)==0)
 	    fprintf(stderr," ");
 	fprintf(stderr,"0x%.2x ",*(ptr+i));

--- a/vrrp_netgraph.c
+++ b/vrrp_netgraph.c
@@ -165,7 +165,7 @@ int vrrp_netgraph_create_eiface(char *ng_name, char *ether_name, struct ether_ad
 					return -1;
 				}
 				snprintf(name, sizeof(name), "%s", ng_name);
-				if (NgNameNode(ng_control_socket, path, name) < 0) {
+				if (NgNameNode(ng_control_socket, path, "%s", name) < 0) {
 					free(ngmsg);
 					return -1;
 				}

--- a/vrrp_signal.c
+++ b/vrrp_signal.c
@@ -57,12 +57,11 @@ void
 vrrp_signal_quit(int sig)
 {
 	int             cpt = 0;
-	struct ether_addr ethaddr;
 
 	vrrp_thread_mutex_lock();
 	vrrp_netgraph_shutdown_allnodes();
 	while (vr_ptr[cpt]) {
-		ethaddr = vrrp_list_get_first(vr_ptr[cpt]);
+		vrrp_list_get_first(vr_ptr[cpt]);
 		vrrp_interface_vripaddr_delete(vr_ptr[cpt]);
 		close(vr_ptr[cpt]->sd);
 		close(vr_ptr[cpt]->ioctl_sd);


### PR DESCRIPTION
## Summary
- **vrrp_signal.c**: Remove unused `ethaddr` variable — `vrrp_list_get_first()` return value was assigned but never read.
- **vrrp_ah.c**: Cast `unsigned char *` to `void *` for `%p` format specifier in `hexdump()`.
- **vrrp_netgraph.c**: Pass `name` through `"%s"` format to `NgNameNode()` which is declared `__printflike(3, 4)`.

Builds clean with zero warnings on FreeBSD 14.2 / clang 18.