### PR TITLE
Fix stale netgraph nodes reused on restart

### DIFF
--- a/vrrp_functions.h
+++ b/vrrp_functions.h
@@ -128,4 +128,4 @@ char            vrrp_thread_create_vrid(struct vrrp_vr *);
 int		vrrp_netgraph_bridge_create(char *);
 int		vrrp_netgraph_create_virtualiface(struct vrrp_vr *);
 int		vrrp_netgraph_shutdown(int, char *);
-int		vrrp_netgraph_shutdown_allnodes(void);
+int		vrrp_netgraph_teardown(void);

--- a/vrrp_main.c
+++ b/vrrp_main.c
@@ -242,6 +242,7 @@ main(int argc, char **argv)
 	bzero(&vr_ptr, sizeof(vr_ptr));
 	syslog(LOG_NOTICE, "initializing threads and all VRID");
 	vrrp_thread_initialize();
+	vrrp_netgraph_teardown();  /* Clean stale nodes from previous run */
 	syslog(LOG_NOTICE, "reading configuration file %s", copt.conffile);
 	while (!coderet) {
 		vr = (struct vrrp_vr *)calloc(1, sizeof(struct vrrp_vr));

--- a/vrrp_netgraph.c
+++ b/vrrp_netgraph.c
@@ -243,7 +243,7 @@ int vrrp_netgraph_create_virtualiface(struct vrrp_vr *vr) {
 	return 0;
 }
 
-int vrrp_netgraph_shutdown_allnodes(void) {
+int vrrp_netgraph_teardown(void) {
 	struct nodeinfo *ninfo;
 	struct namelist *nlist;
 	struct ng_mesg *ngmsg;

--- a/vrrp_netgraph.c
+++ b/vrrp_netgraph.c
@@ -243,6 +243,25 @@ int vrrp_netgraph_create_virtualiface(struct vrrp_vr *vr) {
 	return 0;
 }
 
+/*
+ * Check if a netgraph node exists by ID.
+ * Returns 1 if node exists, 0 if not, -1 on error.
+ */
+static int vrrp_netgraph_node_exists(int ng_control_socket, ng_ID_t node_id) {
+	struct ng_mesg *reply;
+	char path[256];
+
+	snprintf(path, sizeof(path), "[%x]:", node_id);
+	if (NgSendMsg(ng_control_socket, path, NGM_GENERIC_COOKIE, NGM_NODEINFO, NULL, 0) < 0)
+		return 0;  /* Node doesn't exist */
+
+	if (NgAllocRecvMsg(ng_control_socket, &reply, NULL) < 0)
+		return -1;  /* Error receiving reply */
+
+	free(reply);
+	return 1;  /* Node exists */
+}
+
 int vrrp_netgraph_teardown(void) {
 	struct nodeinfo *ninfo;
 	struct namelist *nlist;
@@ -261,10 +280,21 @@ int vrrp_netgraph_teardown(void) {
 	ninfo = nlist->nodeinfo;
 	while (nlist->numnames > 0) {
 		if (! strncmp(ninfo->name, VRRP_NETGRAPH_BASENAME, strlen(VRRP_NETGRAPH_BASENAME))) {
-			snprintf(path, sizeof(path), "%s:", ninfo->name);
+			ng_ID_t node_id = ninfo->id;
+
+			/* Shutdown by ID to avoid name reuse races */
+			snprintf(path, sizeof(path), "[%x]:", node_id);
 			vrrp_netgraph_shutdown(ng_control_socket, path);
+
+			/*
+			 * Wait for node to actually be destroyed.
+			 * No timeout needed: kernel panics if node won't die
+			 * (NGF_REALLY_DIE flag), so this loop always terminates.
+			 */
+			while (vrrp_netgraph_node_exists(ng_control_socket, node_id) == 1)
+				usleep(1000);  /* 1ms poll */
 		}
-		ninfo++;	
+		ninfo++;
 		nlist->numnames--;
 	}
 

--- a/vrrp_signal.c
+++ b/vrrp_signal.c
@@ -60,7 +60,7 @@ vrrp_signal_quit(int sig)
 	struct ether_addr ethaddr;
 
 	vrrp_thread_mutex_lock();
-	vrrp_netgraph_shutdown_allnodes();
+	vrrp_netgraph_teardown();
 	while (vr_ptr[cpt]) {
 		ethaddr = vrrp_list_get_first(vr_ptr[cpt]);
 		vrrp_interface_vripaddr_delete(vr_ptr[cpt]);


### PR DESCRIPTION
## Summary

- After shutdown or crash, stale netgraph nodes can persist with old IP addresses. On restart, freevrrpd searches for any unhooked eiface node and may grab an orphaned one with wrong IP configuration.
- Rename `vrrp_netgraph_shutdown_allnodes()` to `vrrp_netgraph_teardown()` and call it at startup to destroy stale nodes before creating new ones.
- Make teardown synchronous using node ID paths (`[id]:`) instead of name paths, with polling to confirm destruction. Prevents "File exists" errors on rapid restart.

Rebased from the previously closed PR #2 onto current master.