### PR TITLE
Fix skew_time integer truncation per RFC 3768 §6.1

### DIFF
--- a/vrrp_main.c
+++ b/vrrp_main.c
@@ -71,8 +71,8 @@ vrrp_main_post_init(struct vrrp_vr * vr, int firstime)
 	vr->ethaddr.octet[3] = 0x00;
 	vr->ethaddr.octet[4] = 0x01;
 	vr->ethaddr.octet[5] = vr->vr_id;
-	vr->skew_time = (256 - vr->priority) / 256;
-	vr->master_down_int = (3 * vr->adv_int) + vr->skew_time;
+	vr->skew_time = ((256 - vr->priority) * 1000) / 256;
+	vr->master_down_int = (3 * vr->adv_int * 1000) + vr->skew_time;
 	if (firstime) {
 		vrrp_misc_get_if_infos(vr->vr_if->if_name, &vr->vr_if->ethaddr, vr->vr_if->ip_addrs, &size);
 		if (! vr->vr_if->ip_addrs[0].s_addr) {
@@ -134,8 +134,8 @@ vrrp_main_print_struct(struct vrrp_vr * vr)
 	for (cpt = 0; cpt < vr->cnt_ip; cpt++)
 		fprintf(stderr, "\t%s\n", inet_ntoa(vr->vr_ip[cpt].addr));
 	fprintf(stderr, "VServer ADV_INT\t\t: %u\n", vr->adv_int);
-	fprintf(stderr, "VServer MASTER_DW_TM\t: %u\n", vr->master_down_int);
-	fprintf(stderr, "VServer SKEW_TIME\t: %u\n", vr->skew_time);
+	fprintf(stderr, "VServer MASTER_DW_TM\t: %u ms\n", vr->master_down_int);
+	fprintf(stderr, "VServer SKEW_TIME\t: %u ms\n", vr->skew_time);
 	fprintf(stderr, "VServer State\t\t: %u\n", vr->state);
 	fprintf(stderr, "Server IF_NAME\t\t: %s\n", vr->vr_if->if_name);
 	fprintf(stderr, "Server NB_IP\t\t: %u\n", vr->vr_if->nb_ip);

--- a/vrrp_misc.c
+++ b/vrrp_misc.c
@@ -245,8 +245,8 @@ vrrp_misc_compute_checksum(u_short * addr, register int len)
 	return answer;
 }
 
-char 
-vrrp_misc_calcul_tminterval(struct timeval * timer, u_int interval)
+char
+vrrp_misc_calcul_tminterval(struct timeval * timer, u_int interval_ms)
 {
 	struct timeval  tm;
 
@@ -254,8 +254,12 @@ vrrp_misc_calcul_tminterval(struct timeval * timer, u_int interval)
 		syslog(LOG_ERR, "cannot get time with gettimeofday: %s", strerror(errno));
 		return -1;
 	}
-	timer->tv_sec = tm.tv_sec + interval;
-	timer->tv_usec = tm.tv_usec;
+	timer->tv_sec = tm.tv_sec + interval_ms / 1000;
+	timer->tv_usec = tm.tv_usec + (interval_ms % 1000) * 1000;
+	if (timer->tv_usec >= 1000000) {
+		timer->tv_sec++;
+		timer->tv_usec -= 1000000;
+	}
 
 	return 0;
 }

--- a/vrrp_proto.h
+++ b/vrrp_proto.h
@@ -112,8 +112,8 @@ struct vrrp_vr {
 	struct vrrp_vip *vr_ip;
 	u_int          *vr_netmask;
 	u_char          adv_int;
-	u_int           master_down_int;
-	u_int           skew_time;
+	u_int           master_down_int;	/* milliseconds */
+	u_int           skew_time;		/* milliseconds */
 	struct vrrp_timer tm;
 	u_char          preempt_mode;	/* False = 0, True = 1 */
 	u_char          state;	/* 0 = INITIALIZE, 1 = MASTER, 2 = BACKUP */

--- a/vrrp_state.c
+++ b/vrrp_state.c
@@ -86,7 +86,7 @@ vrrp_state_set_master(struct vrrp_vr * vr)
 		syslog(LOG_NOTICE, "waiting %d seconds for the spanning tree latency", vr->spanningTreeLatency);
 		sleep(vr->spanningTreeLatency);
 	}
-	if (vrrp_misc_calcul_tminterval(&vr->tm.adv_tm, vr->adv_int) == -1)
+	if (vrrp_misc_calcul_tminterval(&vr->tm.adv_tm, vr->adv_int * 1000) == -1)
 		return -1;
 	vr->state = VRRP_STATE_MASTER;
 	syslog(LOG_NOTICE, "server state vrid %d: master", vr->vr_id);
@@ -131,8 +131,8 @@ vrrp_state_set_backup(struct vrrp_vr * vr)
 		syslog(LOG_NOTICE, "waiting %d seconds for the spanning tree latency", vr->spanningTreeLatency);
 		sleep(vr->spanningTreeLatency);
 	}
-	vr->skew_time = (256 - vr->priority) / 256;
-	vr->master_down_int = (3 * vr->adv_int) + vr->skew_time;
+	vr->skew_time = ((256 - vr->priority) * 1000) / 256;
+	vr->master_down_int = (3 * vr->adv_int * 1000) + vr->skew_time;
 	if (vrrp_misc_calcul_tminterval(&vr->tm.master_down_tm, vr->master_down_int) == -1)
 		return -1;
 	vr->state = VRRP_STATE_BACKUP;
@@ -196,7 +196,7 @@ vrrp_state_master(struct vrrp_vr * vr)
 				if (vr->sd == -1)
 					return -1;
 				vrrp_network_send_advertisement(vr);
-				if (vrrp_misc_calcul_tminterval(&vr->tm.adv_tm, vr->adv_int) == -1)
+				if (vrrp_misc_calcul_tminterval(&vr->tm.adv_tm, vr->adv_int * 1000) == -1)
 					return -1;
 				continue;
 			}
@@ -213,7 +213,7 @@ vrrp_state_master(struct vrrp_vr * vr)
 				return 0;
 			}
 			vrrp_network_send_advertisement(vr);
-			if (vrrp_misc_calcul_tminterval(&vr->tm.adv_tm, vr->adv_int) == -1)
+			if (vrrp_misc_calcul_tminterval(&vr->tm.adv_tm, vr->adv_int * 1000) == -1)
 				return -1;
 			continue;
 		}


### PR DESCRIPTION
## Summary

- The RFC defines Skew_Time as `(256 - Priority) / 256` in fractional seconds, but integer division always produced 0 for any priority >= 1. This gave every BACKUP the same `master_down_interval` regardless of priority, defeating the RFC's race-prevention mechanism.
- Switch `calcul_tminterval` to accept milliseconds and compute skew_time as `((256 - Priority) * 1000) / 256` ms. A priority-254 BACKUP now promotes in ~3007ms vs ~3996ms for priority-1, matching RFC intent.